### PR TITLE
Update githook embeds to credit commit author, not commit committer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # FICSIT-Fred
 
-A Discord bot for the Satisfactory Modding Discord
+A Discord bot for the Satisfactory Modding Discord.
+Features automatic log file and crash report analysis and runtime-editable commands to help answer common questions.
 
 ---
 
@@ -21,16 +22,17 @@ These intents are needed to receive the content of messages and receive member j
 
 Docker is for making containers. If you're not sure what that means, look it up it's real cool! In our case, it helps
 use set up all needed dependencies for Fred without you needing to do anything other than install Docker.
-You can get docker [here](https://docs.docker.com/engine/install/). For Linux, make sure to **not** use Docker Desktop.
-For Windows, it is the easiest way.
+On Linux, use [Docker Engine](https://docs.docker.com/engine/install/) instead of Docker Desktop.
+On Windows, [Docker Desktop](https://docs.docker.com/desktop/setup/install/windows-install/) is the easiest way.
 If you don't want to install Docker (especially on Windows where Docker Desktop can take up resources and requires
-virtualization to be enabled), you can also manually set up a PostgreSQL DB and configure Fred to point to it. 
+virtualization to be enabled), you can also manually set up a PostgreSQL DB and configure Fred to point to it,
+which is outside the scope of this guide.
 
 ---
 
 ### Setup
 
-Two choices here: All through docker or hybrid local/docker.
+Two choices here: All through Docker or hybrid local/Docker.
 We recommend the hybrid way for ease of development. We don't have a proper devcontainer setup so debugging Fred when
 running in Docker is not great.
 Instead, in a hybrid setup, you'll use Docker for the Postgres DB only and run Fred locally using Poetry.
@@ -50,13 +52,13 @@ You can use `fred@fred.com` for the user and `fred` for the password. All of thi
 
 For this, you'll need [poetry](https://python-poetry.org/).
 
-**Make sure you are using a compatible version of python, or Fred will not build!** 
+**Make sure you are using a compatible version of python, or Fred will not build!**
 You can find the version requirements in the [`pyproject.toml`](pyproject.toml).
 We recommend the use of [pyenv](https://github.com/pyenv/pyenv) to install the best version.
 
-Create a virtual environment with `poetry env use`, using the python version mentioned above. Then run`poetry install`.
-This should create a `.venv` folder that contains the virtualenv with all the necessary packages. 
-Activate it using the script pointed to by `poetry env activate`.
+Create a virtual environment with `poetry env use python_version_here`, using the python version mentioned above. Then run `poetry install`.
+This should create a `.venv` folder that contains the virtualenv with all the necessary packages.
+Activate it [running the script output when executing `poetry env activate`](https://python-poetry.org/docs/managing-environments).
 
 Now, run `docker compose -f docker-compose-deps.yml up -d`. This should spin up the postgres DB.
 You can verify that the database was properly created and manage it by going to <http://localhost:8080> where pgadmin
@@ -86,6 +88,15 @@ Finally, run `python -m fred` or `poetry run fred`. You can now adapt this to yo
 script from your IDE instead. Don't forget to use the virtualenv python!
 
 ---
+
+## Contributing
+
+Contribute to this project via pull requests.
+It's best to discuss changes with the team on the [Satisfactory Modding Discord](https://discord.ficsit.app) first.
+
+Make sure to run the Python [Black formatter](https://github.com/psf/black) before committing.
+To do this, run `black .` in the root of the project.
+This will follow the style rules set in the `pyproject.toml`.
 
 ## Thanks
 

--- a/cspell.json
+++ b/cspell.json
@@ -8,11 +8,14 @@
   "words": [
     "Borketh",
     "dberrors",
+    "Feyko",
     "FICSIT",
     "libpq",
     "Mircea",
     "owoize",
     "pgadmin",
+    "pyenv",
+    "pyproject",
     "virtualenv"
   ],
   // flagWords - list of words to be always considered incorrect

--- a/fred/libraries/createembed.py
+++ b/fred/libraries/createembed.py
@@ -79,6 +79,7 @@ def DM(text: str) -> nextcord.Embed:
     return embed
 
 
+# data format: expand `commits` properties on: https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
 def format_commit(commit: dict) -> tuple[str, str]:
     hash_id = f'`{commit["id"][:8]}`'
     commit_message = commit["message"].split("\n")[0].replace("*", r"\*")
@@ -91,6 +92,7 @@ def format_commit(commit: dict) -> tuple[str, str]:
     return f"{commit_message}\n", f'{change_summary_icons} - by {attribution} {ts} [{hash_id}]({commit["url"]})\n'
 
 
+# data format: https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
 def push(data: dict) -> nextcord.Embed:
     if data["forced"]:
         colour = config.ActionColours.fetch("Red")
@@ -100,10 +102,10 @@ def push(data: dict) -> nextcord.Embed:
         forced = ""
 
     if data["created"]:
-        embed = create(data)
+        embed = push_ref_create(data)
         return embed
     elif data["deleted"]:
-        embed = delete(data)
+        embed = push_ref_delete(data)
         return embed
 
     commits = data["commits"]
@@ -127,6 +129,7 @@ def push(data: dict) -> nextcord.Embed:
     return embed
 
 
+# data format: (note: docs on 'added' has empty data for `member` but it probably shares it with 'removed'?) https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=removed#member
 def contributor_added(data: dict) -> nextcord.Embed:
     embed = nextcord.Embed(
         title=f'__**{data["member"]["login"]}**__ has been added to the Repository!',
@@ -139,6 +142,7 @@ def contributor_added(data: dict) -> nextcord.Embed:
     return embed
 
 
+# data format: https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request
 def pull_request(data: dict) -> nextcord.Embed:
     action = data["action"]
     colour = config.ActionColours.fetch("Orange")
@@ -189,7 +193,8 @@ def pull_request(data: dict) -> nextcord.Embed:
     return embed
 
 
-def create(data: dict) -> nextcord.Embed:
+# data format: https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
+def push_ref_create(data: dict) -> nextcord.Embed:
     _, ref_type, ref_name = data["ref"].split("/")
     match ref_type:
         case "tags":
@@ -210,7 +215,8 @@ def create(data: dict) -> nextcord.Embed:
     return embed
 
 
-def delete(data: dict) -> nextcord.Embed:
+# data format: https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
+def push_ref_delete(data: dict) -> nextcord.Embed:
     _, ref_type, ref_name = data["ref"].split("/")
     embed = nextcord.Embed(
         title=f'{ref_type} "{ref_name}" deleted in {repo_name}',
@@ -223,6 +229,7 @@ def delete(data: dict) -> nextcord.Embed:
     return embed
 
 
+# data format: https://docs.github.com/en/webhooks/webhook-events-and-payloads#release
 def release(data: dict) -> nextcord.Embed:
     state = "pre-release" if data["release"]["prerelease"] else "release"
     embed = nextcord.Embed(
@@ -236,6 +243,7 @@ def release(data: dict) -> nextcord.Embed:
     return embed
 
 
+# data format: https://docs.github.com/en/webhooks/webhook-events-and-payloads#issues
 def issue(data: dict) -> nextcord.Embed:
     match action := data["action"]:
         case "opened":
@@ -257,6 +265,7 @@ def issue(data: dict) -> nextcord.Embed:
     return embed
 
 
+# data format: https://docs.github.com/en/webhooks/webhook-events-and-payloads#issue_comment
 def issue_comment(data: dict) -> nextcord.Embed:
     author = data["comment"]["user"]
     embed = nextcord.Embed(

--- a/fred/libraries/createembed.py
+++ b/fred/libraries/createembed.py
@@ -91,6 +91,8 @@ def format_commit(commit: dict) -> tuple[str, str]:
     )
     return f"{commit_message}\n", f'{change_summary_icons} - by {attribution} {ts} [{hash_id}]({commit["url"]})\n'
 
+def _append_legend_footer(embed: nextcord.Embed) -> None:
+    embed.set_footer(text="Use the `" + config.Misc.fetch("prefix") + "legend` to learn what the icons mean!")
 
 # data format: https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
 def push(data: dict) -> nextcord.Embed:
@@ -125,7 +127,7 @@ def push(data: dict) -> nextcord.Embed:
         embed.add_field(name=f"{not_shown} commits not shown", value="See GitHub for more details!", inline=False)
 
     embed.set_author(name=data["sender"]["login"], icon_url=data["sender"]["avatar_url"])
-    embed.set_footer(text="Use the `" + config.Misc.fetch("prefix") + "legend` to learn what the icons mean!")
+    _append_legend_footer(embed)
     return embed
 
 
@@ -187,9 +189,7 @@ def pull_request(data: dict) -> nextcord.Embed:
 
     direction = f'{data["pull_request"]["head"]["ref"]} -> {data["pull_request"]["base"]["ref"]}'
     embed.add_field(name=direction, value=stats)
-
-    embed.set_footer(text="Use the `" + config.Misc.fetch("prefix") + "legend` to learn what the icons mean!")
-
+    _append_legend_footer(embed)
     return embed
 
 

--- a/fred/libraries/createembed.py
+++ b/fred/libraries/createembed.py
@@ -83,7 +83,7 @@ def DM(text: str) -> nextcord.Embed:
 def format_commit(commit: dict) -> tuple[str, str]:
     hash_id = f'`{commit["id"][:8]}`'
     commit_message = commit["message"].split("\n")[0].replace("*", r"\*")
-    author = commit["committer"]
+    author = commit["author"]
     attribution = f'[{author["name"]}](https://github.com/{author["username"]})'
     ts = timestamp(commit["timestamp"])
     change_summary_icons = " ".join(
@@ -126,6 +126,8 @@ def push(data: dict) -> nextcord.Embed:
     if not_shown := len(commits[24:]):
         embed.add_field(name=f"{not_shown} commits not shown", value="See GitHub for more details!", inline=False)
 
+    # Note: if we wanted to get user display name instead of username,
+    # looks like we'd have to web request the `url` field then use the `name` field from the response
     embed.set_author(name=data["sender"]["login"], icon_url=data["sender"]["avatar_url"])
     _append_legend_footer(embed)
     return embed


### PR DESCRIPTION
(Needs #218 first because git moment)

Update the git webhook embeds to credit commit author, not committer. With the previous field usage of committer, when someone rebases something, the whole rebase embed looks like the committer wrote every change (no, they didn't, the commits have different authors)

Also adds links to the webhook payload docs.

I don't have a working dev fred right now but I am pretty confident from the github API docs + output of git commands locally that this Should™ work. Testing would be appreciated.

Black still doesn't run locally for me but I think I followed format and line max length